### PR TITLE
Allow GitHub users with non-public email

### DIFF
--- a/db/migrations/20161128160702_optional_user_email.rb
+++ b/db/migrations/20161128160702_optional_user_email.rb
@@ -1,0 +1,8 @@
+Hanami::Model.migration do
+  change do
+    alter_table :users do
+      set_column_allow_null :email
+      drop_constraint :email
+    end
+  end
+end


### PR DESCRIPTION
Just drop the "unique" constraint and allow email field to be empty.