### PR TITLE
Do not email constraint

### DIFF
--- a/db/migrations/20161128160702_optional_user_email.rb
+++ b/db/migrations/20161128160702_optional_user_email.rb
@@ -2,7 +2,6 @@ Hanami::Model.migration do
   change do
     alter_table :users do
       set_column_allow_null :email
-      drop_constraint :email
     end
   end
 end


### PR DESCRIPTION
Before this commit migration on postgres broke:

```
Sequel::DatabaseError: PG::UndefinedObject: ERROR: constraint "email" of relation "users" does not exist
```

Sadly, I've only tested it with sqlite.
Now, I have postgres up and running.

Sorry for that :-(